### PR TITLE
Added instructions for creating conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ python cli.py
 
 This method only allows the GUI program to function, any other file will need to modify the python path to use neurochat.
 
+
+### Option 4: Use `conda`
+
+It is also possible to install *NeuroChaT* into a `conda` (Anaconda) environment
+
+```
+git clone https://github.com/seankmartin/NeuroChaT
+cd NeuroChaT
+conda create -f environment.yml
+pip install .
+python cli.py
+```
+
 ### Install PyQt5 on linux
 
 If you are running NeuroChaT GUI on linux, after installing the requirements you will need to install further qt programs.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: neurochat_test
+name: neurochat
 channels:
 - defaults
 - anaconda
@@ -15,3 +15,4 @@ dependencies:
 - PyYAML
 - xlrd
 - openpyxl
+- lxml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: neurochat_test
+channels:
+- defaults
+- anaconda
+- conda-forge
+dependencies:
+- PyPDF2
+- pyqt
+- h5py
+- matplotlib
+- numpy
+- pandas
+- scipy
+- scikit-learn
+- PyYAML
+- xlrd
+- openpyxl


### PR DESCRIPTION
Installing *NeuroChaT* into an `conda` environment could be a convenient option for some users.
This commits adds an `environment.yml` file for setting up a suitable `conda` environment (including the installation of the necessary dependencies) as well as a short hint in the *Installation* section of the `README.md` file on how to use the environment file.